### PR TITLE
Peekable only takes one argument

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -134,7 +134,7 @@ struct Context<'ctx, 'parser: 'ctx> {
     list_options: HashMap<Rc<GenericOption<'parser>>, Vec<&'ctx str>>,
     list_arguments: HashMap<Rc<GenericArgument<'parser>>, Vec<&'ctx str>>,
     arguments: Vec<&'ctx str>,
-    iter: Peekable<&'ctx String, Iter<'ctx, String>>,
+    iter: Peekable<Iter<'ctx, String>>,
     stderr: &'ctx mut (Writer + 'ctx),
 }
 


### PR DESCRIPTION
Hi,

The following patch fixes the way Peekable is used against the latest nightly.

```bash
rustc --version
rustc 1.0.0-nightly (b63cee4a1 2015-02-14 17:01:11 +0000)
```