### PR TITLE
Added Cargo.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /greeting
 /structure
 
+# Cargo files
+Cargo.lock


### PR DESCRIPTION
Hi,

This PR ignores the `Cargo.lock`, as discussed in rust-lang/cargo#315. The recommendation seems to be that libraries should ignore the `Cargo.lock` file, whereas applications/binaries should track it.