### PR TITLE
fix rfc 1214 fallout

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ mod bool;
 mod num;
 mod from_cli;
 
-pub trait FromCommandLine {
+pub trait FromCommandLine: Sized {
     fn from_argument(s: &str) -> Result<Self, String>;
 }
 


### PR DESCRIPTION
[RFC 1214](https://github.com/rust-lang/rfcs/blob/master/text/1214-projections-lifetimes-and-wf.md) fixed some bugs / incorrect behaviour in `rustc` which requires additional bounds in some places.

The errors were:
```plain
src/lib.rs:17:5: 17:55 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/lib.rs:17     fn from_argument(s: &str) -> Result<Self, String>;
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:17:5: 17:55 help: run `rustc --explain E0277` to see a detailed explanation
src/lib.rs:17:5: 17:55 note: `Self` does not have a constant size known at compile-time
src/lib.rs:17     fn from_argument(s: &str) -> Result<Self, String>;
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:17:5: 17:55 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/lib.rs:17     fn from_argument(s: &str) -> Result<Self, String>;
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:17:5: 17:55 note: required by `core::result::Result`
src/lib.rs:17     fn from_argument(s: &str) -> Result<Self, String>;
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```