### PR TITLE
Remove Copy constraint in Actions, and document weaker Clone constraint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -253,24 +253,25 @@ The following actions are available out of the box. They may be used in either
 
 ``Store``
     An option has single argument. Stores a value from command-line in a
-    variable. Any type that has ``FromStr`` trait implemented may be used.
+    variable. Any type that has the ``FromStr`` and ``Clone`` traits implemented
+    may be used.
 
 ``StoreOption``
     As ``Store``, but wrap value with ``Some`` for use with ``Option``. For
     example:
-    
+
         let mut x: Option<i32> = None;
         ap.refer(&mut x).add_option(&["-x"], StoreOption, "Set var x");
 
 ``StoreConst(value)``
     An option has no arguments. Store a hard-coded ``value`` into variable,
-    when specified. Any type may be used.
+    when specified. Any type with the ``Clone`` trait implemented may be used.
 
 ``PushConst(value)``
     An option has no arguments. Push a hard-coded ``value`` into variable,
-    when specified. Any type may be used. Option might used for a list of
-    operations to perform, when ``required`` is set for this variable, at least
-    one operation is required.
+    when specified. Any type which has the ``Clone`` type implemented may be
+    used. Option might used for a list of operations to perform, when ``required``
+    is set for this variable, at least one operation is required.
 
 ``StoreTrue``
     Stores boolean ``true`` value in a variable.
@@ -283,11 +284,11 @@ The following actions are available out of the box. They may be used in either
 
 ``IncrBy(num)``
     An option has no arguments. Increments the value stored in a variable by a
-    value ``num``. Any type which has ``Add`` trait may be used.
+    value ``num``. Any type which has the ``Add`` and ``Clone`` traits may be used.
 
 ``DecrBy(nym)``
     Decrements the value stored in a variable by a value ``num``. Any type
-    which has ``Add`` trait may be used.
+    which has the ``Add`` and ``Clone`` traits may be used.
 
 ``Collect``
     When used for an ``--option``, requires single argument. When used for a

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -31,17 +31,17 @@ pub struct ListAction<'a, T: 'a> {
     cell: Rc<RefCell<&'a mut Vec<T>>>,
 }
 
-impl<T: 'static + Copy> TypedAction<T> for StoreConst<T> {
+impl<T: 'static + Clone> TypedAction<T> for StoreConst<T> {
     fn bind<'x>(&self, cell: Rc<RefCell<&'x mut T>>) -> Action<'x> {
-        let StoreConst(val) = *self;
-        return Flag(Box::new(StoreConstAction { cell: cell, value: val }));
+        let StoreConst(ref val) = *self;
+        return Flag(Box::new(StoreConstAction { cell: cell, value: val.clone() }));
     }
 }
 
-impl<T: 'static + Copy> TypedAction<Vec<T>> for PushConst<T> {
+impl<T: 'static + Clone> TypedAction<Vec<T>> for PushConst<T> {
     fn bind<'x>(&self, cell: Rc<RefCell<&'x mut Vec<T>>>) -> Action<'x> {
-        let PushConst(val) = *self;
-        return Flag(Box::new(PushConstAction { cell: cell, value: val }));
+        let PushConst(ref val) = *self;
+        return Flag(Box::new(PushConstAction { cell: cell, value: val.clone() }));
     }
 }
 
@@ -69,18 +69,18 @@ impl<T: 'static + FromStr + Clone> TypedAction<Vec<T>> for Collect {
     }
 }
 
-impl<'a, T: Copy> IFlagAction for StoreConstAction<'a, T> {
+impl<'a, T: Clone> IFlagAction for StoreConstAction<'a, T> {
     fn parse_flag(&self) -> ParseResult {
         let mut targ = self.cell.borrow_mut();
-        **targ = self.value;
+        **targ = self.value.clone();
         return Parsed;
     }
 }
 
-impl<'a, T: Copy> IFlagAction for PushConstAction<'a, T> {
+impl<'a, T: Clone> IFlagAction for PushConstAction<'a, T> {
     fn parse_flag(&self) -> ParseResult {
         let mut targ = self.cell.borrow_mut();
-        targ.push(self.value);
+        targ.push(self.value.clone());
         return Parsed;
     }
 }

--- a/src/num.rs
+++ b/src/num.rs
@@ -18,34 +18,40 @@ pub struct DecrByAction<'a, T: 'a> {
     cell: Rc<RefCell<&'a mut T>>,
 }
 
-impl<T: 'static + Add<Output = T> + Copy> TypedAction<T> for IncrBy<T> {
+impl<T: 'static + Add<Output = T> + Clone> TypedAction<T> for IncrBy<T> {
     fn bind<'x>(&self, cell: Rc<RefCell<&'x mut T>>) -> Action<'x> {
-        let IncrBy(delta) = *self;
-        return Flag(Box::new(IncrByAction { cell: cell, delta: delta }));
+        let IncrBy(ref delta) = *self;
+        return Flag(Box::new(IncrByAction { cell: cell, delta: delta.clone() }));
     }
 }
 
-impl<T: 'static + Sub<Output = T> + Copy> TypedAction<T> for DecrBy<T> {
+impl<T: 'static + Sub<Output = T> + Clone> TypedAction<T> for DecrBy<T> {
     fn bind<'x>(&self, cell: Rc<RefCell<&'x mut T>>) -> Action<'x> {
-        let DecrBy(delta) = *self;
-        return Flag(Box::new(DecrByAction { cell: cell, delta: delta }));
+        let DecrBy(ref delta) = *self;
+        return Flag(Box::new(DecrByAction { cell: cell, delta: delta.clone() }));
     }
 }
 
-impl<'a, T: Add<Output = T> + Copy> IFlagAction for IncrByAction<'a, T> {
+impl<'a, T: Add<Output = T> + Clone> IFlagAction for IncrByAction<'a, T> {
     fn parse_flag(&self) -> ParseResult {
+        let oldval = {
+            let targ = self.cell.borrow();
+            targ.clone()
+        };
         let mut targ = self.cell.borrow_mut();
-        let oldval = **targ;
-        **targ = oldval + self.delta;
+        **targ = oldval + self.delta.clone();
         return Parsed;
     }
 }
 
-impl<'a, T: Sub<Output = T> + Copy> IFlagAction for DecrByAction<'a, T> {
+impl<'a, T: Sub<Output = T> + Clone> IFlagAction for DecrByAction<'a, T> {
     fn parse_flag(&self) -> ParseResult {
+        let oldval = {
+            let targ = self.cell.borrow();
+            targ.clone()
+        };
         let mut targ = self.cell.borrow_mut();
-        let oldval = **targ;
-        **targ = oldval - self.delta;
+        **targ = oldval - self.delta.clone();
         return Parsed;
     }
 }

--- a/src/test_parser.rs
+++ b/src/test_parser.rs
@@ -1,4 +1,3 @@
-use std::str::from_utf8;
 
 use parser::ArgumentParser;
 


### PR DESCRIPTION
This is not a breaking change - existing code will continue working since Copy: Clone. Removes the Copy constraint on types involved with Actions, and replaces it with a weaker Clone constraint. There should be no performance impact on existing code.

Additionally, this pull request adds to the readme to show that those constraints are required.

Finally, when I was running the tests, I noticed an unused "use" statement, which I removed in an individual commit.