### PR TITLE
Make help message more consistent (capitalization and indentation)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ what we have now::
 
     Greet somebody.
 
-    optional arguments:
+    Optional arguments:
      -h, --help  show this help message and exit
      -v, --verbose
                  Be verbose

--- a/README.rst
+++ b/README.rst
@@ -59,15 +59,16 @@ what we have now::
 
     $ rustc greeting.rs
     $ ./greeting -h
-    Usage: ./greeting [OPTIONS]
+    Usage:
+      ./greeting [OPTIONS]
 
     Greet somebody.
 
     Optional arguments:
-     -h, --help  show this help message and exit
-     -v, --verbose
+      -h, --help  show this help message and exit
+      -v, --verbose
                  Be verbose
-     --name NAME Name for the greeting
+      --name NAME Name for the greeting
     $ ./greeting
     Hello World!
     $ ./greeting --name Bob

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -920,7 +920,7 @@ impl<'a, 'b> HelpFormatter<'a, 'b> {
     }
 
     fn write_usage(&mut self) -> IoResult<()> {
-        try!(write!(self.buf, "Usage:\n    "));
+        try!(write!(self.buf, "Usage:\n  "));
         try!(write!(self.buf, "{}", self.name));
         if self.parser.options.len() != 0 {
             if self.parser.short_options.len() > 1

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -897,7 +897,7 @@ impl<'a, 'b> HelpFormatter<'a, 'b> {
         if self.parser.arguments.len() > 0
             || self.parser.catchall_argument.is_some()
         {
-            try!(write!(self.buf, "\npositional arguments:\n"));
+            try!(write!(self.buf, "\nPositional arguments:\n"));
             for arg in self.parser.arguments.iter() {
                 try!(self.print_argument(&**arg));
             }
@@ -911,7 +911,7 @@ impl<'a, 'b> HelpFormatter<'a, 'b> {
         if self.parser.short_options.len() > 0
             || self.parser.long_options.len() > 0
         {
-            try!(write!(self.buf, "\noptional arguments:\n"));
+            try!(write!(self.buf, "\nOptional arguments:\n"));
             for opt in self.parser.options.iter() {
                 try!(self.print_option(&**opt));
             }

--- a/src/test_help.rs
+++ b/src/test_help.rs
@@ -10,7 +10,7 @@ fn test_empty() {
     ap.set_description("Test program");
     assert!(ap.print_help("./argparse_test", &mut buf).is_ok());
     assert_eq!("Usage:\n".to_string()
-        + "    ./argparse_test\n"
+        + "  ./argparse_test\n"
         + "\n"
         + "Test program\n"
         + "\n"
@@ -36,7 +36,7 @@ fn test_options() {
     let mut buf = Vec::<u8>::new();
     assert!(ap.print_help("./argparse_test", &mut buf).is_ok());
     assert_eq!("Usage:\n".to_string()
-        + "    ./argparse_test [OPTIONS]
+        + "  ./argparse_test [OPTIONS]
 
 Test program. The description of the program is ought to be very long, because
 we want to test how word wrapping works for it. So some more text would be ok
@@ -61,7 +61,7 @@ fn test_argument() {
     let mut buf = Vec::<u8>::new();
     assert!(ap.print_help("./argparse_test", &mut buf).is_ok());
     assert_eq!("Usage:\n".to_string()
-        + "    ./argparse_test [VALUE]\n"
+        + "  ./argparse_test [VALUE]\n"
         + "\n"
         + "Test program\n"
         + "\n"
@@ -88,7 +88,7 @@ fn test_arguments() {
     let mut buf = Vec::<u8>::new();
     assert!(ap.print_help("./argparse_test", &mut buf).is_ok());
     assert_eq!("Usage:\n".to_string()
-        + "    ./argparse_test [V1] [V2 ...]\n"
+        + "  ./argparse_test [V1] [V2 ...]\n"
         + "\n"
         + "Test program\n"
         + "\n"
@@ -118,7 +118,7 @@ fn test_req_arguments() {
     let mut buf = Vec::<u8>::new();
     assert!(ap.print_help("./argparse_test", &mut buf).is_ok());
     assert_eq!("Usage:\n".to_string()
-        + "    ./argparse_test V1 V2 [...]\n"
+        + "  ./argparse_test V1 V2 [...]\n"
         + "\n"
         + "Test program\n"
         + "\n"
@@ -143,7 +143,7 @@ fn test_metavar() {
     let mut buf = Vec::<u8>::new();
     assert!(ap.print_help("./argparse_test", &mut buf).is_ok());
     assert_eq!("Usage:\n".to_string()
-        + "    ./argparse_test [OPTIONS]\n"
+        + "  ./argparse_test [OPTIONS]\n"
         + "\n"
         + "Test program.\n"
         + "\n"

--- a/src/test_help.rs
+++ b/src/test_help.rs
@@ -14,7 +14,7 @@ fn test_empty() {
         + "\n"
         + "Test program\n"
         + "\n"
-        + "optional arguments:\n"
+        + "Optional arguments:\n"
         + "  -h,--help             show this help message and exit\n"
         , from_utf8(&buf[..]).unwrap().to_string());
 }
@@ -42,7 +42,7 @@ Test program. The description of the program is ought to be very long, because
 we want to test how word wrapping works for it. So some more text would be ok
 for the test\n"
         + "\n"
-        + "optional arguments:\n"
+        + "Optional arguments:\n"
         + "  -h,--help             show this help message and exit\n"
         + "  --value VALUE         Set integer value\n"
         + "  -L,--long-option LONG_OPTION\n"
@@ -65,10 +65,10 @@ fn test_argument() {
         + "\n"
         + "Test program\n"
         + "\n"
-        + "positional arguments:\n"
+        + "Positional arguments:\n"
         + "  value                 Integer value\n"
         + "\n"
-        + "optional arguments:\n"
+        + "Optional arguments:\n"
         + "  -h,--help             show this help message and exit\n"
         , from_utf8(&buf[..]).unwrap().to_string());
 }
@@ -92,11 +92,11 @@ fn test_arguments() {
         + "\n"
         + "Test program\n"
         + "\n"
-        + "positional arguments:\n"
+        + "Positional arguments:\n"
         + "  v1                    Integer value 1\n"
         + "  v2                    More values\n"
         + "\n"
-        + "optional arguments:\n"
+        + "Optional arguments:\n"
         + "  -h,--help             show this help message and exit\n"
         , from_utf8(&buf[..]).unwrap().to_string());
 }
@@ -122,11 +122,11 @@ fn test_req_arguments() {
         + "\n"
         + "Test program\n"
         + "\n"
-        + "positional arguments:\n"
+        + "Positional arguments:\n"
         + "  v1                    Integer value 1\n"
         + "  v2                    More values\n"
         + "\n"
-        + "optional arguments:\n"
+        + "Optional arguments:\n"
         + "  -h,--help             show this help message and exit\n"
         , from_utf8(&buf[..]).unwrap().to_string());
 }
@@ -147,7 +147,7 @@ fn test_metavar() {
         + "\n"
         + "Test program.\n"
         + "\n"
-        + "optional arguments:\n"
+        + "Optional arguments:\n"
         + "  -h,--help             show this help message and exit\n"
         + "  -L,--long-option VAL  Long option value\n"
         , from_utf8(&buf[..]).unwrap().to_string());

--- a/src/test_usage.rs
+++ b/src/test_usage.rs
@@ -8,7 +8,7 @@ fn test_empty() {
     let ap = ArgumentParser::new();
     let mut buf = Vec::<u8>::new();
     assert!(ap.print_usage("./argparse_test", &mut buf).is_ok());
-    assert_eq!("Usage:\n    ./argparse_test\n", from_utf8(&buf[..]).unwrap());
+    assert_eq!("Usage:\n  ./argparse_test\n", from_utf8(&buf[..]).unwrap());
 }
 
 #[test]
@@ -22,7 +22,7 @@ fn test_options() {
             "Set integer value");
         assert!(ap.print_usage("./argparse_test", &mut buf).is_ok());
     }
-    assert_eq!("Usage:\n    ./argparse_test [OPTIONS]\n",
+    assert_eq!("Usage:\n  ./argparse_test [OPTIONS]\n",
         from_utf8(&buf[..]).unwrap());
 }
 
@@ -35,7 +35,7 @@ fn test_argument() {
         "Integer value");
     let mut buf = Vec::<u8>::new();
     assert!(ap.print_usage("./argparse_test", &mut buf).is_ok());
-    assert_eq!("Usage:\n    ./argparse_test [VALUE]\n",
+    assert_eq!("Usage:\n  ./argparse_test [VALUE]\n",
         from_utf8(&buf[..]).unwrap());
 }
 
@@ -52,6 +52,6 @@ fn test_arguments() {
         "More values");
     let mut buf = Vec::<u8>::new();
     assert!(ap.print_usage("./argparse_test", &mut buf).is_ok());
-    assert_eq!("Usage:\n    ./argparse_test [V1] [V2 ...]\n",
+    assert_eq!("Usage:\n  ./argparse_test [V1] [V2 ...]\n",
         from_utf8(&buf[..]).unwrap());
 }


### PR DESCRIPTION
It looks better (IMO) and it’s also consistent with “Usage” that is already capitalized.