### PR TITLE
Wildcar dependency not allowed by Crates.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,8 +18,7 @@ Edit your Cargo.toml to add ``rust-argparse`` to your project.
 .. code-block:: rust
 
     [dependencies]
-
-    argparse = "*"
+    argparse = "0.2.1"
 
 
 Example


### PR DESCRIPTION
In your Readme file you recommend to add `argparse = "*"` dependency but this is not allowed when you publish your librairy on [Crates.io](http://crates.io/).