### PR TITLE
README.rst: make example compile

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,7 +129,7 @@ You may add multiple options for the same variable::
 
 Similarly positional arguments are added::
 
-    let mut command = String;
+    let mut command = String::new();
     parser.refer(&mut command)
         .add_argument("command", Store,
                       "Command to run");


### PR DESCRIPTION
hi,

just started using argparse, and while going through the step-by-step in the README, i thought "wait, that doesn't compile unless they do some black magic". after i found no black magic, i'm now proposing this little fix :-)