### PR TITLE
Make Print action print to the proper io::Write object

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 pub enum ParseResult {
     Parsed,
     Help,
-    Exit,
+    Exit(Option<String>),
     Error(String),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,3 +62,4 @@ pub struct DecrBy<T>(pub T);
 #[cfg(test)] mod test_env;
 #[cfg(test)] mod test_const;
 #[cfg(test)] mod test_path;
+#[cfg(test)] mod test_print;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -743,7 +743,16 @@ impl<'parser> ArgumentParser<'parser> {
         let name = if !args.is_empty() { &args[0][..] } else { "unknown" };
         match Context::parse(self, &args, stderr) {
             Parsed => return Ok(()),
-            Exit => return Err(0),
+            Exit(message) => {
+                if let Some(message) = message {
+                    if message.ends_with('\n') {
+                        write!(stdout, "{}", message).unwrap();
+                    } else {
+                        writeln!(stdout, "{}", message).unwrap();
+                    }
+                }
+                return Err(0);
+            },
             Help => {
                 self.print_help(name, stdout).unwrap();
                 return Err(0);

--- a/src/print.rs
+++ b/src/print.rs
@@ -3,11 +3,6 @@ use action::{IFlagAction, ParseResult};
 
 impl IFlagAction for Print {
     fn parse_flag(&self) -> ParseResult {
-        if self.0.ends_with('\n') {
-            print!("{}", self.0);
-        } else {
-            println!("{}", self.0);
-        }
-        return ParseResult::Exit;
+        return ParseResult::Exit(Some(self.0.clone()));
     }
 }

--- a/src/test_parser.rs
+++ b/src/test_parser.rs
@@ -17,7 +17,7 @@ pub fn check_ok(ap: &ArgumentParser, args: &[&str]) {
     }
 }
 
-pub fn check_exit(ap: &ArgumentParser, args: &[&str]) {
+pub fn check_exit(ap: &ArgumentParser, args: &[&str]) -> (Vec<u8>, Vec<u8>) {
     let mut stdout = Vec::<u8>::new();
     let mut stderr = Vec::<u8>::new();
     let mut owned_args = Vec::new();
@@ -26,7 +26,7 @@ pub fn check_exit(ap: &ArgumentParser, args: &[&str]) {
     }
     let res = ap.parse(owned_args, &mut stdout, &mut stderr);
     match res {
-        Err(0) => return,
+        Err(0) => return (stdout, stderr),
         Err(x) => panic!(format!("Expected code {} got {}", 0usize, x)),
         Ok(()) => panic!(format!("Expected failure, got success")),
     }

--- a/src/test_print.rs
+++ b/src/test_print.rs
@@ -1,0 +1,19 @@
+use parser::ArgumentParser;
+use super::Print;
+use test_parser::{check_exit};
+
+fn print_str(args: &[&str]) -> String {
+    let mut ap = ArgumentParser::new();
+    ap.add_option(&["-V", "--version"],
+        Print("program 0.42".to_string()),
+        "Print version");
+    let (out, _) = check_exit(&ap, args);
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+#[test]
+fn test_str() {
+    let expected = "program 0.42\n".to_string();
+    assert_eq!(print_str(&["./argparse_test", "-V"]), expected);
+    assert_eq!(print_str(&["./argparse_test", "--version"]), expected);
+}


### PR DESCRIPTION
The Print action prints data straight to stdout, which is not what users
expect from a context where custom stdout and stderr io::Write objects
can be supplied.
This change fixes the problem. It piggy-backs on the Exit variant of the
ParseResult enum and adds an optional String argument to it. This
argument, if present, will be printed to the correct io::Write object
that the user intended to represent stdout, just before exiting the
program.