### PR TITLE
Silence compiler warnings.

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -10,14 +10,14 @@ pub enum ParseResult {
 
 
 pub enum Action<'a> {
-    Flag(Box<IFlagAction + 'a>),
-    Single(Box<IArgAction + 'a>),
-    Push(Box<IArgsAction + 'a>),
-    Many(Box<IArgsAction + 'a>),
+    Flag(Box<dyn IFlagAction + 'a>),
+    Single(Box<dyn IArgAction + 'a>),
+    Push(Box<dyn IArgsAction + 'a>),
+    Many(Box<dyn IArgsAction + 'a>),
 }
 
 pub trait TypedAction<T> {
-    fn bind<'x>(&self, Rc<RefCell<&'x mut T>>) -> Action<'x>;
+    fn bind<'x>(&self, _:Rc<RefCell<&'x mut T>>) -> Action<'x>;
 }
 
 pub trait IFlagAction {

--- a/src/help.rs
+++ b/src/help.rs
@@ -61,7 +61,7 @@ impl<'a> Iterator for WordsIter<'a> {
     }
 }
 
-pub fn wrap_text(buf: &mut Write, data: &str, width: usize, indent: usize)
+pub fn wrap_text(buf: &mut dyn Write, data: &str, width: usize, indent: usize)
     -> IoResult<()>
 {
     let mut witer = WordsIter::new(data);
@@ -71,22 +71,22 @@ pub fn wrap_text(buf: &mut Write, data: &str, width: usize, indent: usize)
             return Ok(());
         }
         Some(word) => {
-            try!(buf.write_all(word.as_bytes()));
+            buf.write_all(word.as_bytes())?;
             off += word.len();
         }
     }
     for word in witer {
         if off + word.len() + 1 > width {
-            try!(buf.write_all(b"\n"));
+            buf.write_all(b"\n")?;
             for _ in 0..indent {
-                try!(buf.write_all(b" "));
+                buf.write_all(b" ")?;
             }
             off = indent;
         } else {
-            try!(buf.write_all(b" "));
+            buf.write_all(b" ")?;
             off += 1;
         }
-        try!(buf.write_all(word.as_bytes()));
+        buf.write_all(word.as_bytes())?;
         off += word.len();
     }
     return Ok(());


### PR DESCRIPTION
Compiler is warning that constructs used are deprecated and suggests alternative approaches. This commit implements those suggestions.