### PR TITLE
add more helpful panic on empty names

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -514,6 +514,9 @@ impl<'parser, 'refer, T> Ref<'parser, 'refer, T> {
         -> &'x mut Ref<'parser, 'refer, T>
     {
         {
+            if names.is_empty() {
+                panic!("At least one name for option must be specified");
+            }
             let var = &mut self.parser.vars[self.varid];
             if var.metavar.is_empty() {
                 let mut longest_name = names[0];

--- a/src/test_usage.rs
+++ b/src/test_usage.rs
@@ -27,6 +27,15 @@ fn test_options() {
 }
 
 #[test]
+#[should_panic(expected="At least one name for option must be specified")]
+fn test_option_empty_names() {
+  let mut val = 0;
+  let mut ap = ArgumentParser::new();
+  ap.refer(&mut val)
+    .add_option(&[], Store, "Set integer value");
+}
+
+#[test]
 fn test_argument() {
     let mut val = 0;
     let mut ap = ArgumentParser::new();


### PR DESCRIPTION
Add more helpful panic text when `add_option(...)` used with empty `names` as described in #45  